### PR TITLE
Receiver: Set toast to content text not title

### DIFF
--- a/Superuser/src/com/koushikdutta/superuser/SuReceiver.java
+++ b/Superuser/src/com/koushikdutta/superuser/SuReceiver.java
@@ -54,8 +54,8 @@ public class SuReceiver extends BroadcastReceiver {
         case Settings.NOTIFICATION_TYPE_NOTIFICATION:
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
             builder.setTicker(toast)
-            .setContentTitle(toast)
-            .setContentText("")
+            .setContentTitle(context.getString(R.string.app_name))
+            .setContentText(toast)
             .setSmallIcon(R.drawable.ic_stat_notification);
             
             NotificationManager nm = (NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);


### PR DESCRIPTION
Currently the notification toast runs over the borders of the notification. Can barely see what app requested superuser. 
http://i.imgur.com/OFXpWHg.png

So, set the toast as the content text and leave app_name for notification title.
