### PR TITLE
added possibility to change ndk-executable

### DIFF
--- a/Superuser/build.xml
+++ b/Superuser/build.xml
@@ -69,13 +69,13 @@
     <import file="custom_rules.xml" optional="true" />
 
     <target name="-pre-build">
-        <exec executable="${ndk.dir}/ndk-build" failonerror="true">
+        <exec executable="${ndk.dir}/${ndk.executable}" failonerror="true">
           <arg value="-j8" />
         </exec>
     </target>
 
     <target name="clean" depends="android_rules.clean">
-        <exec executable="${ndk.dir}/ndk-build" failonerror="true">
+        <exec executable="${ndk.dir}/${ndk.executable}" failonerror="true">
             <arg value="clean"/>
         </exec>
         <delete file="bin/update.zip"/>

--- a/Superuser/project.properties
+++ b/Superuser/project.properties
@@ -13,3 +13,4 @@
 # Project target.
 target=android-17
 android.library.reference.1=../../Widgets/Widgets
+ndk.executable=ndk-build


### PR DESCRIPTION
In order to be able to build on windows ndk-build must be changed to ndk-build.cmd. Easiest would be to add  a build property and use local.properties to set ndk.executable in order to build on windows. Default stays as is using project.properties.
