### PR TITLE
AndroidManifest to use the "signature" protection

### DIFF
--- a/Superuser/AndroidManifest.xml
+++ b/Superuser/AndroidManifest.xml
@@ -10,10 +10,10 @@
 
     <permission
         android:name="android.permission.REQUEST_SUPERUSER"
-        android:protectionLevel="signatureOrSystem" />
+        android:protectionLevel="signature" />
     <permission
         android:name="android.permission.REPORT_SUPERUSER"
-        android:protectionLevel="signatureOrSystem" />
+        android:protectionLevel="signature" />
 
     <permission-group
         android:name="android.permission-group.SUPERUSER"


### PR DESCRIPTION
Updated the available permissions of REQUEST_SUPERUSER and REPORT_SUPERUSER to "signature" rather than "signatureOrSystem" since it is more strict and wouldn't allow access by other (unknown and possibly malicious) system apps.
