### PR TITLE
Better terminal support in Superuser for interactive sessions

### DIFF
--- a/Superuser/jni/Android.mk
+++ b/Superuser/jni/Android.mk
@@ -6,7 +6,7 @@ LOCAL_MODULE := su
 LOCAL_LDFLAGS := -static
 LOCAL_STATIC_LIBRARIES := sqlite3
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/sqlite3
-LOCAL_SRC_FILES := su/su.c su/activity.c su/db.c su/utils.c su/daemon.c
+LOCAL_SRC_FILES := su/su.c su/activity.c su/db.c su/utils.c su/daemon.c su/pts.c
 include $(BUILD_EXECUTABLE)
 
 

--- a/Superuser/jni/su/daemon.c
+++ b/Superuser/jni/su/daemon.c
@@ -108,6 +108,10 @@ static int run_daemon_child(int infd, int outfd, int errfd, int argc, char** arg
         exit(-1);
     }
 
+    close(infd);
+    close(outfd);
+    close(errfd);
+
     return main(argc, argv);
 }
 

--- a/Superuser/jni/su/pts.c
+++ b/Superuser/jni/su/pts.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2013, Tan Chee Eng (@tan-ce)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+ * pts.c
+ *
+ * Manages the pseudo-terminal driver on Linux/Android and provides some
+ * helper functions to handle raw input mode and terminal window resizing
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <termios.h>
+#include <errno.h>
+#include <pthread.h>
+
+#include "pts.h"
+
+/**
+ * pts_open
+ *
+ * Opens a pts device and returns the name of the slave tty device.
+ *
+ * Arguments
+ * slave_name       the name of the slave device
+ * slave_name_size  the size of the buffer passed via slave_name
+ *
+ * Return Values
+ * on failure either -2 or -1 (errno set) is returned.
+ * on success, the file descriptor of the master device is returned.
+ */
+int pts_open(char *slave_name, size_t slave_name_size) {
+    int fdm;
+    char *sn_tmp;
+
+    // Open master ptmx device
+    fdm = open("/dev/ptmx", O_RDWR);
+    if (fdm == -1) return -1;
+
+    // Get the slave name
+    sn_tmp = ptsname(fdm);
+    if (!sn_tmp) {
+        close(fdm);
+        return -2;
+    }
+
+    strncpy(slave_name, sn_tmp, slave_name_size);
+    slave_name[slave_name_size - 1] = '\0';
+
+    // Grant, then unlock
+    if (grantpt(fdm) == -1) {
+        close(fdm);
+        return -1;
+    }
+    if (unlockpt(fdm) == -1) {
+        close(fdm);
+        return -1;
+    }
+
+    return fdm;
+}
+
+// Stores the previous termios of stdin
+static struct termios old_stdin;
+static int stdin_is_raw = 0;
+
+/**
+ * set_stdin_raw
+ *
+ * Changes stdin to raw unbuffered mode, disables echo, 
+ * auto carriage return, etc.
+ *
+ * Return Value
+ * on failure -1, and errno is set
+ * on success 0
+ */
+int set_stdin_raw(void) {
+    struct termios new_termios;
+
+    // Save the current stdin termios
+    if (tcgetattr(STDIN_FILENO, &old_stdin) < 0) {
+        return -1;
+    }
+
+    // Start from the current settings
+    new_termios = old_stdin;
+
+    // Make the terminal like an SSH or telnet client
+    new_termios.c_iflag |= IGNPAR;
+    new_termios.c_iflag &= ~(ISTRIP | INLCR | IGNCR | ICRNL | IXON | IXANY | IXOFF);
+    new_termios.c_lflag &= ~(ISIG | ICANON | ECHO | ECHOE | ECHOK | ECHONL);
+    new_termios.c_oflag &= ~OPOST;
+    new_termios.c_cc[VMIN] = 1;
+    new_termios.c_cc[VTIME] = 0;
+
+    if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &new_termios) < 0) {
+        return -1;
+    }
+
+    stdin_is_raw = 1;
+
+    return 0;
+}
+
+/**
+ * restore_stdin
+ *
+ * Restore termios on stdin to the state it was before
+ * set_stdin_raw() was called. If set_stdin_raw() was
+ * never called, does nothing and doesn't return an error.
+ *
+ * This function is async-safe.
+ *
+ * Return Value
+ * on failure, -1 and errno is set
+ * on success, 0
+ */
+int restore_stdin(void) {
+    if (!stdin_is_raw) return 0;
+
+    if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &old_stdin) < 0) {
+        return -1;
+    }
+
+    stdin_is_raw = 0;
+
+    return 0;
+}
+
+// Flag indicating whether the sigwinch watcher should terminate.
+volatile static int closing_time = 0;
+
+/**
+ * Thread process. Wait for a SIGWINCH to be received, then update 
+ * the terminal size.
+ */
+static void *watch_sigwinch(void *data) {
+    sigset_t winch;
+    int sig;
+    int master = ((int *)data)[0];
+    int slave = ((int *)data)[1];
+
+    sigemptyset(&winch);
+    sigaddset(&winch, SIGWINCH);
+
+    do {
+        // Wait for a SIGWINCH
+        sigwait(&winch, &sig);
+
+        if (closing_time) break;
+
+        // Get the new terminal size
+        struct winsize w;
+        if (ioctl(master, TIOCGWINSZ, &w) == -1) {
+            continue;
+        }
+
+        // Set the new terminal size
+        ioctl(slave, TIOCSWINSZ, &w);
+
+    } while (1);
+
+    free(data);
+    return NULL;
+}
+
+/**
+ * watch_sigwinch_async
+ *
+ * After calling this function, if the application receives
+ * SIGWINCH, the terminal window size will be read from 
+ * "input" and set on "output".
+ *
+ * NOTE: This function blocks SIGWINCH and spawns a thread.
+ *
+ * Arguments
+ * master   A file descriptor of the TTY window size to follow
+ * slave    A file descriptor of the TTY window size which is
+ *          to be set on SIGWINCH
+ *
+ * Return Value
+ * on failure, -1 and errno will be set. In this case, no
+ *      thread has been spawned and SIGWINCH will not be 
+ *      blocked.
+ * on success, 0
+ */
+int watch_sigwinch_async(int master, int slave) {
+    pthread_t watcher;
+    int *files = (int *) malloc(sizeof(int) * 2);
+    if (files == NULL) {
+        return -1;
+    }
+
+    // Block SIGWINCH so sigwait can later receive it
+    sigset_t winch;
+    sigemptyset(&winch);
+    sigaddset(&winch, SIGWINCH);
+    if (sigprocmask(SIG_BLOCK, &winch, NULL) == -1) {
+        free(files);
+        return -1;
+    }
+
+    // Initialize some variables, then start the thread
+    closing_time = 0;
+    files[0] = master;
+    files[1] = slave;
+    int ret = pthread_create(&watcher, NULL, &watch_sigwinch, files);
+    if (ret != 0) {
+        free(files);
+        errno = ret;
+        return -1;
+    }
+
+    // Set the initial terminal size
+    raise(SIGWINCH);
+}
+
+/**
+ * watch_sigwinch_cleanup
+ *
+ * Cause the SIGWINCH watcher thread to terminate
+ */
+void watch_sigwinch_cleanup(void) {
+    closing_time = 1;
+    raise(SIGWINCH);
+}

--- a/Superuser/jni/su/pts.h
+++ b/Superuser/jni/su/pts.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2013, Tan Chee Eng (@tan-ce)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+ * pts.h
+ *
+ * Manages the pseudo-terminal driver on Linux/Android and provides some
+ * helper functions to handle raw input mode and terminal window resizing
+ */
+
+#ifndef _PTS_H_
+#define _PTS_H_
+
+/**
+ * pts_open
+ *
+ * Opens a pts device and returns the name of the slave tty device.
+ *
+ * Arguments
+ * slave_name       the name of the slave device
+ * slave_name_size  the size of the buffer passed via slave_name
+ *
+ * Return Values
+ * on failure either -2 or -1 (errno set) is returned.
+ * on success, the file descriptor of the master device is returned.
+ */
+int pts_open(char *slave_name, size_t slave_name_size);
+
+/**
+ * set_stdin_raw
+ *
+ * Changes stdin to raw unbuffered mode, disables echo, 
+ * auto carriage return, etc.
+ *
+ * Return Value
+ * on failure -1, and errno is set
+ * on success 0
+ */
+int set_stdin_raw(void);
+
+/**
+ * restore_stdin
+ *
+ * Restore termios on stdin to the state it was before
+ * set_stdin_raw() was called. If set_stdin_raw() was
+ * never called, does nothing and doesn't return an error.
+ *
+ * This function is async-safe.
+ *
+ * Return Value
+ * on failure, -1 and errno is set
+ * on success, 0
+ */
+int restore_stdin(void);
+
+/**
+ * watch_sigwinch_async
+ *
+ * After calling this function, if the application receives
+ * SIGWINCH, the terminal window size will be read from 
+ * "input" and set on "output".
+ *
+ * NOTE: This function blocks SIGWINCH and spawns a thread.
+ *
+ * Arguments
+ * master   A file descriptor of the TTY window size to follow
+ * slave    A file descriptor of the TTY window size which is
+ *          to be set on SIGWINCH
+ *
+ * Return Value
+ * on failure, -1 and errno will be set. In this case, no
+ *      thread has been spawned and SIGWINCH will not be 
+ *      blocked.
+ * on success, 0
+ */
+int watch_sigwinch_async(int master, int slave);
+
+/**
+ * watch_sigwinch_cleanup
+ *
+ * Cause the SIGWINCH watcher thread to terminate
+ */
+void watch_sigwinch_cleanup(void);
+#endif

--- a/Superuser/jni/su/pts.h
+++ b/Superuser/jni/su/pts.h
@@ -94,4 +94,23 @@ int watch_sigwinch_async(int master, int slave);
  * Cause the SIGWINCH watcher thread to terminate
  */
 void watch_sigwinch_cleanup(void);
+
+/**
+ * pump_stdin_async
+ *
+ * Forward data from STDIN to the given FD
+ * in a seperate thread
+ */
+void pump_stdin_async(int outfd);
+
+/**
+ * pump_stdout_blocking
+ *
+ * Forward data from the FD to STDOUT.
+ * Returns when the remote end of the FD closes.
+ *
+ * Before returning, restores stdin settings.
+ */
+void pump_stdout_blocking(int infd);
+
 #endif


### PR DESCRIPTION
Changed the way the daemon and client handles interactive (ie. standard I/O attached to a termnal emulator) sessions. 

Main change is that for interactive sessions, the client opens the pts device and passes the slave device path to the daemon, then the daemon opens and dups the slave device.

The client also puts stdin into raw mode, removing buffering and therefore allowing ncurses apps to function as expected.

Finally, the client also waits for SIGWINCH and forwards the terminal window size every time the signal is received.

The changes are fairly extensive because setting up the slave terminal to be the child's controlling TTY correctly has a slightly different flow from using pipes to wrap the child's standard I/O.
