### PR TITLE
Update version check to work with >= 4.3

### DIFF
--- a/Superuser/assets/update-binary
+++ b/Superuser/assets/update-binary
@@ -55,25 +55,26 @@ chmod 644 /system/app/Superuser.apk
 
 # if the system is at least 4.3, and there is no su daemon built in,
 # let's try to install it using install-recovery.sh
-BUILD_RELEASE_VERSION=$(cat /system/build.prop | grep ro\\.build\\.version\\.release)
-IS_43=$(echo $BUILD_RELEASE_VERSION | grep 4\\.3)
-if [ ! -z "$IS_43" ]
+BUILD_RELEASE_VERSION="$(grep 'ro\.build\.version\.release' /system/build.prop)"
+VERSION="${BUILD_RELEASE_VERSION##*=}"
+MAJ=${VERSION%%.*}
+MIN=${VERSION#*.}
+MIN=${MIN//.*}
+
+if [ "$MAJ" -ge 4 -a "$MIN" -ge 3 ]
 then
-  if [ "$IS_43" \> "4.3"  -o "$IS_43" == "4.3" ]
+  # check for rom su daemon before clobbering install-recovery.sh
+  if [ ! -f "/system/etc/.has_su_daemon" ]
   then
-    # check for rom su daemon before clobbering install-recovery.sh
-    if [ ! -f "/system/etc/.has_su_daemon" ]
-    then
-        echo -n -e 'ui_print Installing Superuser daemon...\n' > /proc/self/fd/$2
-        echo -n -e 'ui_print\n' > /proc/self/fd/$2
-        chattr -i /system/etc/install-recovery.sh
-        cp install-recovery.sh /system/etc/install-recovery.sh
-        chmod 755 /system/etc/install-recovery.sh
-        # note that an post install su daemon was installed
-        # so recovery doesn't freak out and recommend you disable
-        # the install-recovery.sh execute bit.
-        touch /system/etc/.installed_su_daemon
-    fi
+      echo -n -e 'ui_print Installing Superuser daemon...\n' > /proc/self/fd/$2
+      echo -n -e 'ui_print\n' > /proc/self/fd/$2
+      chattr -i /system/etc/install-recovery.sh
+      cp install-recovery.sh /system/etc/install-recovery.sh
+      chmod 755 /system/etc/install-recovery.sh
+      # note that an post install su daemon was installed
+      # so recovery doesn't freak out and recommend you disable
+      # the install-recovery.sh execute bit.
+      touch /system/etc/.installed_su_daemon
   fi
 fi
 


### PR DESCRIPTION
Now that 4.4 is out, the check was failing and not properly setting up
the su daemon.

Using POSIX sh parameter substitution allows us to extract the major and
minor version numbers from ro.build.version.release in build.prop and
compare them.

This was tested on a Nexus 4 running 4.4.
