### PR TITLE
assets: Add missing mips/ symlink

### DIFF
--- a/Superuser/assets/mips
+++ b/Superuser/assets/mips
@@ -1,0 +1,1 @@
+../libs/mips


### PR DESCRIPTION
Bug #195 added MIPS binaries, but the assets/ symlink was missing.  This
means that update.zip still worked as expected on MIPS, but MIPS binaries
were missing from the apk.
