### PR TITLE
fix: allow su operation for SELinux Enforcing systems

### DIFF
--- a/Superuser/jni/su/daemon.c
+++ b/Superuser/jni/su/daemon.c
@@ -431,28 +431,12 @@ int run_daemon() {
 
     memset(&sun, 0, sizeof(sun));
     sun.sun_family = AF_LOCAL;
-    sprintf(sun.sun_path, "%s/server", REQUESTOR_DAEMON_PATH);
-
-    /*
-     * Delete the socket to protect from situations when
-     * something bad occured previously and the kernel reused pid from that process.
-     * Small probability, isn't it.
-     */
-    unlink(sun.sun_path);
-    unlink(REQUESTOR_DAEMON_PATH);
-
-    int previous_umask = umask(027);
-    mkdir(REQUESTOR_DAEMON_PATH, 0777);
+    sprintf(sun.sun_path, "%c%s/server", '\0', REQUESTOR_DAEMON_PATH);
 
     if (bind(fd, (struct sockaddr*)&sun, sizeof(sun)) < 0) {
         PLOGE("daemon bind");
         goto err;
     }
-
-    chmod(REQUESTOR_DAEMON_PATH, 0755);
-    chmod(sun.sun_path, 0777);
-
-    umask(previous_umask);
 
     if (listen(fd, 10) < 0) {
         PLOGE("daemon listen");
@@ -549,7 +533,7 @@ int connect_daemon(int argc, char *argv[], int ppid) {
 
     memset(&sun, 0, sizeof(sun));
     sun.sun_family = AF_LOCAL;
-    sprintf(sun.sun_path, "%s/server", REQUESTOR_DAEMON_PATH);
+    sprintf(sun.sun_path, "%c%s/server", '\0', REQUESTOR_DAEMON_PATH);
 
     if (0 != connect(socketfd, (struct sockaddr*)&sun, sizeof(sun))) {
         PLOGE("connect");

--- a/Superuser/src/com/koushikdutta/superuser/MultitaskSuRequestActivity.java
+++ b/Superuser/src/com/koushikdutta/superuser/MultitaskSuRequestActivity.java
@@ -140,7 +140,6 @@ public class MultitaskSuRequestActivity extends FragmentActivity {
         }
         catch (Exception ex) {
         }
-        new File(mSocketPath).delete();
     }
 
     public static final String PERMISSION = "android.permission.ACCESS_SUPERUSER";
@@ -303,7 +302,7 @@ public class MultitaskSuRequestActivity extends FragmentActivity {
             public void run() {
                 try {
                     mSocket = new LocalSocket();
-                    mSocket.connect(new LocalSocketAddress(mSocketPath, Namespace.FILESYSTEM));
+                    mSocket.connect(new LocalSocketAddress(mSocketPath, Namespace.ABSTRACT));
 
                     DataInputStream is = new DataInputStream(mSocket.getInputStream());
                     
@@ -391,21 +390,6 @@ public class MultitaskSuRequestActivity extends FragmentActivity {
         setContentView();
 
         manageSocket();
-        
-        
-        // watch for the socket disappearing. that means su died.
-        new Runnable() {
-            public void run() {
-                if (isFinishing())
-                    return;
-                if (!new File(mSocketPath).exists()) {
-                    finish();
-                    return;
-                }
-                
-                mHandler.postDelayed(this, 1000);
-            };
-        }.run();
         
         mHandler.postDelayed(new Runnable() {
             @Override


### PR DESCRIPTION
This patch uses virtual resource names for IPC, which is currently not under the purview of
SELinux, for now at least :)
