### PR TITLE
Prevent clickjacking of superuser requests

### DIFF
--- a/Superuser/res/layout/request.xml
+++ b/Superuser/res/layout/request.xml
@@ -119,6 +119,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:enabled="false"
+            android:filterTouchesWhenObscured="true"
             android:text="@string/allow" />
     </LinearLayout>
 


### PR DESCRIPTION
Enable filterTouchesWhenObscured on the accept request button to prevent
possible clickjacking attacks. This is a measure used in many sensitive
dialogs (app installation, backup & VPN) in AOSP.
